### PR TITLE
fix: webview-bridge 타입 에러

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -16,6 +16,7 @@
     "@trpc/client": "^10.45.2",
     "@trpc/react-query": "^10.45.2",
     "@trpc/server": "^10.45.2",
+    "@webview-bridge/react-native": "^1.4.2",
     "react": "18.2.0",
     "react-native": "0.74.0",
     "react-native-dotenv": "^3.4.11",

--- a/apps/webview/package.json
+++ b/apps/webview/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@pinit/app": "workspace:^",
-    "@webview-bridge/react": "^1.4.1",
-    "@webview-bridge/web": "^1.4.1",
+    "@webview-bridge/react": "^1.4.2",
+    "@webview-bridge/web": "^1.4.2",
     "next": "^14.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/webview/tsconfig.json
+++ b/apps/webview/tsconfig.json
@@ -5,16 +5,10 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "declaration": false,
+    "declarationMap": false
   },
-  "declaration": false,
-  "declarationMap": false,
-  "include": [
-    "next-env.d.ts",
-    "next.config.js",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
+  "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@webview-bridge/react-native": "^1.4.1",
     "eslint": "8.57.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@webview-bridge/react-native':
-        specifier: ^1.4.1
-        version: 1.4.2(react-native-webview@13.8.7(react-native@0.74.0(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(@types/react@18.2.61)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -48,6 +45,9 @@ importers:
       '@trpc/server':
         specifier: ^10.45.2
         version: 10.45.2
+      '@webview-bridge/react-native':
+        specifier: ^1.4.2
+        version: 1.4.2(react-native-webview@13.8.7(react-native@0.74.0(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(@types/react@18.2.61)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -216,14 +216,14 @@ importers:
         specifier: workspace:^
         version: link:../app
       '@webview-bridge/react':
-        specifier: ^1.4.1
+        specifier: ^1.4.2
         version: 1.4.2(@webview-bridge/web@1.4.2)(react@18.2.0)
       '@webview-bridge/web':
-        specifier: ^1.4.1
+        specifier: ^1.4.2
         version: 1.4.2
       next:
         specifier: ^14.1.1
-        version: 14.1.1(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -10254,7 +10254,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@14.1.1(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.1.1
       '@swc/helpers': 0.5.2
@@ -10264,7 +10264,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.24.4)(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.1
       '@next/swc-darwin-x64': 14.1.1
@@ -11145,12 +11145,10 @@ snapshots:
 
   strnum@1.0.5: {}
 
-  styled-jsx@5.1.1(@babel/core@7.24.4)(react@18.2.0):
+  styled-jsx@5.1.1(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
-    optionalDependencies:
-      '@babel/core': 7.24.4
 
   sudo-prompt@9.2.1: {}
 


### PR DESCRIPTION
안녕하세요 !

https://github.com/daehwahap/monorepo/pull/18 해당 PR을 revert 합니다. 

해당 PR에서 우려주신 사항
* pnpm monorepo에서 root package.json에서 webview-bridge가 설치되는 것은 안좋은 것을 동의합니다.
* `dependencies` 필드에 라이브러리를 아무리 추가해도 번들로 잡히지 않습니다 ! (해당 필드들은 라이브러리에게만 해당되는 필드입니다. 해당 라이브러리가 설치될 때 같이 설치되는 라이브러리의 목록이기에 번들과 관련이 없습니다)

해당 이슈는 tsconfig의 문제입니다.

https://github.com/gronxb/webview-bridge/issues/39#issuecomment-2082314733

제가 마지막에 안내드린 tsconfig의 위치가 잘 못 설정되어 해당 이슈가 생긴 것으로 보입니다.
변경 사항대로 바꾼다면 해당 에러는 정상적으로 해결될 것으로 보입니다 !

![image](https://github.com/daehwahap/monorepo/assets/41789633/d9a580da-932a-4953-bc42-92038b0fe112)

